### PR TITLE
fix: update redirect method after article deletion

### DIFF
--- a/front-end/src/pages/Article.jsx
+++ b/front-end/src/pages/Article.jsx
@@ -38,7 +38,7 @@ const Article = () => {
   const handleDelete = async () => {
     try {
       await axios.delete(url + '/api/article/deletearticle', { data: { id: article._id } });
-      history.push('/article-list'); // Redirect to article list page after deletion
+      window.location.href = '/article-list'; // Redirect to article list page after deletion
     } catch (err) {
       console.error('Error deleting article:', err.message);
       setError('Failed to delete the article.');


### PR DESCRIPTION
As `history.push` method is outdated in React Router v6, so I replace it with `window.location.href`

Related PR: #62 