### PR TITLE
Add ApiError utility for standardized error handling

### DIFF
--- a/back-end/Utils/Api.Error.js
+++ b/back-end/Utils/Api.Error.js
@@ -1,0 +1,57 @@
+// ### ApiError Utility
+
+// The `ApiError` class provides a standardized way to handle API errors in the project.
+
+// ### Features
+// - Consistent error structure for API responses.
+// - Includes `statuscode` (HTTP status code), `message`, `errors` (details), and optional `stack` (debugging information).
+// - Automatically captures stack traces for better debugging.
+
+// ### Parameters
+// - `statuscode` (number): HTTP status code (e.g., 400, 404, 500).
+// - `message` (string): Description of the error (default: "Something went wrong").
+// - `errors` (array): Additional error details (e.g., validation errors).
+// - `stack` (string, optional): Custom stack trace for debugging (default: automatically captured).
+
+// ### Example Usage
+// ```javascript
+// import { ApiError } from './utils/error.js';
+
+// // Example route using ApiError
+// app.get('/example', (req, res, next) => {
+//   try {
+//     throw new ApiError(400, 'Invalid input', ['Missing field: username']);
+//   } catch (error) {
+//     next(error); // Pass the error to the middleware
+//   }
+// });
+// ```
+
+
+
+class ApiError extends Error {
+    constructor(
+      statuscode = 500, // Default to internal server error
+      message = "Something went wrong",
+      errors = [],
+      stack = ""
+    ) {
+      super(message);
+  
+      // Ensure statuscode is a valid number
+      this.statuscode = Number.isInteger(statuscode) ? statuscode : 500;
+      this.data = null;
+      this.message = message;
+      this.success = false;
+      this.errors = Array.isArray(errors) ? errors : [];
+  
+      if (stack) {
+        this.stack = stack;
+      } else {
+        Error.captureStackTrace(this, this.constructor);
+      }
+    }
+  }
+  
+  export { ApiError };
+  

--- a/desktop.ini
+++ b/desktop.ini
@@ -1,0 +1,2 @@
+[.ShellClassInfo]
+LocalizedResourceName=@react-blog,0


### PR DESCRIPTION
### Description
This PR introduces a centralized `ApiError` utility in the `utils` directory to provide a consistent structure for handling API errors.

### Features
- Consistent error response structure including `statuscode`, `message`, `errors`, and `stack`.
- Automatically captures stack traces for better debugging.

### How to Use
Import `ApiError` in your routes or middleware and throw it for standardized error handling:
```javascript
import { ApiError } from './utils/error.js';

app.get('/example', (req, res, next) => {
  try {
    throw new ApiError(404, 'Resource not found', ['Details here']);
  } catch (error) {
    next(error);
  }
});
