### PR TITLE
Add Popup Confirmation for Deleting Articles

### DIFF
--- a/front-end/src/components/AlertDialog.jsx
+++ b/front-end/src/components/AlertDialog.jsx
@@ -1,0 +1,37 @@
+import * as React from "react"
+
+export function AlertDialog({ isOpen, onClose, onConfirm, title, description, confirmText = "Yes", cancelText = "No" }) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center">
+      <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full mx-4">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+          {title}
+        </h2>
+        {description && (
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
+            {description}
+          </p>
+        )}
+        <div className="flex justify-end gap-4">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
+          >
+            {cancelText}
+          </button>
+          <button
+            onClick={() => {
+              onConfirm();
+              onClose();
+            }}
+            className="px-4 py-2 text-sm font-medium text-white bg-red-500 hover:bg-red-600 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+          >
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front-end/src/pages/Article.jsx
+++ b/front-end/src/pages/Article.jsx
@@ -6,6 +6,7 @@ import CommentsList from '../components/CommentsList';
 import AddComment from '../components/AddComment';
 import { link } from '../components/Baselink';
 import LikeButton from '../components/LikeButton';
+import { AlertDialog } from '../components/AlertDialog'; // Update this path based on where you save the AlertDialog component
 
 const Article = ({ loggedInUserId }) => {
   const { name } = useParams();
@@ -13,6 +14,7 @@ const Article = ({ loggedInUserId }) => {
   const [error, setError] = useState(null);
   const [liked, setLiked] = useState(false);
   const [likedBy, setLikedBy] = useState([]);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const url = `${link}`;
 
   useEffect(() => {
@@ -25,8 +27,6 @@ const Article = ({ loggedInUserId }) => {
         console.log(data)
         console.log(localStorage.getItem("token"))
         console.log(localStorage.getItem('userId'))
-        // const decoded = jwt.verify(localStorage.getItem("token").split(" ")[1],"your_very_long_and_random_secret_key_here")
-        // console.log(decoded)
         if (data.name === name) {
           setArticle(data);
           setLiked(data.liked);
@@ -82,7 +82,7 @@ const Article = ({ loggedInUserId }) => {
                 Edit Article
               </button>
               <button
-                onClick={handleDelete}
+                onClick={() => setIsDeleteDialogOpen(true)}
                 className="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded ml-4"
               >
                 Delete Article
@@ -91,6 +91,16 @@ const Article = ({ loggedInUserId }) => {
           )}
         </div>
       </div>
+
+      <AlertDialog
+        isOpen={isDeleteDialogOpen}
+        onClose={() => setIsDeleteDialogOpen(false)}
+        onConfirm={handleDelete}
+        title="Are you sure you want to delete this article?"
+        description="This action cannot be undone. This will permanently delete your article."
+        confirmText="Yes, Delete"
+        cancelText="No, Cancel"
+      />
 
       <div className="prose prose-sm sm:prose-lg mx-auto dark:prose-invert">
         {article.content &&
@@ -121,4 +131,3 @@ const Article = ({ loggedInUserId }) => {
 };
 
 export default Article;
-


### PR DESCRIPTION
### Summary
This pull request adds a popup confirmation dialog when attempting to delete an article. The popup asks the user if they are sure they want to delete the article and provides two options: "Yes" and "No".

### Changes
- Implement a popup confirmation dialog for deleting articles.
- Add "Yes" and "No" buttons to the popup.
- Ensure the article is only deleted if the user confirms by clicking "Yes".

### Screenshots
![Screenshot 2025-01-11 193453](https://github.com/user-attachments/assets/5d01ded3-cfe6-430e-a488-23e363a0f3db)

### Testing
1. Navigate to the article you want to delete.
2. Click the delete button.
3. Verify that a popup appears asking for confirmation.
4. Click "No" and ensure the article is not deleted.
5. Click "Yes" and ensure the article is deleted.

### Related Issue
#134 